### PR TITLE
feat: invalid policy document effect test

### DIFF
--- a/aws_terraform/invald_effect.rego
+++ b/aws_terraform/invald_effect.rego
@@ -1,0 +1,21 @@
+package main
+
+valid_effects = {
+	"Allow",
+	"Deny",
+}
+
+policy_documents_with_invalid_names[r] = resources {
+	changes := input.resource_changes[r]
+	resources := [resource |
+		resource := changes.address
+		changes.type == "aws_iam_policy_document"
+		not valid_effects[changes.change.after.statement[r].effect]
+	]
+}
+
+deny_invalid_effect[msg] {
+	resources := policy_documents_with_invalid_names[_]
+	resources != []
+	msg := sprintf("Policy document has invalid effect: %v", [resources])
+}

--- a/aws_terraform/invalid_effect_test.rego
+++ b/aws_terraform/invalid_effect_test.rego
@@ -1,0 +1,34 @@
+package tests
+
+import data.main as main
+
+test_valid_effect_deny {
+	r := main.deny_invalid_effect with input as {"resource_changes": [{
+		"address": "foo",
+		"type": "aws_iam_policy_document",
+		"change": {"after": {"statement": [{"effect": "Deny"}]}},
+	}]}
+
+	count(r) == 0
+}
+
+test_valid_effect_allow {
+	r := main.deny_invalid_effect with input as {"resource_changes": [{
+		"address": "foo",
+		"type": "aws_iam_policy_document",
+		"change": {"after": {"statement": [{"effect": "Allow"}]}},
+	}]}
+
+	count(r) == 0
+}
+
+test_invalid_effect {
+	r := main.deny_invalid_effect with input as {"resource_changes": [{
+		"address": "foo",
+		"type": "aws_iam_policy_document",
+		"change": {"after": {"statement": [{"effect": "bar"}]}},
+	}]}
+
+	r[_] == "Policy document has invalid effect: [\"foo\"]"
+	count(r) == 1
+}


### PR DESCRIPTION
# Summary | Résumé

 - Ensure that an iam policy document has an effect that's either "Allow" or "Deny"
 - Add tests to check for the new rule
