### PR TITLE
fix: update Postgres max username length to 63

### DIFF
--- a/aws_terraform/postgres_db_main_username.rego
+++ b/aws_terraform/postgres_db_main_username.rego
@@ -20,15 +20,15 @@ main_username_too_long[r] = resources {
 		address := changes.address
 		changes.type == "aws_rds_cluster"
 
-		# needs to be 17 to account for end of the string
-		count(changes.change.after.master_username) >= 17
+		# needs to be 64 to account for end of the string
+		count(changes.change.after.master_username) >= 64
 	]
 }
 
 deny_postgres_main_username_too_long[msg] {
 	address := main_username_too_long[_]
 	address != []
-	msg := sprintf("Postgresql main username > 16 characters: %v", [address])
+	msg := sprintf("Postgresql main username > 63 characters: %v", [address])
 }
 
 main_username_reserved_words[r] = resources {

--- a/aws_terraform/postgres_db_main_username_tests.rego
+++ b/aws_terraform/postgres_db_main_username_tests.rego
@@ -27,11 +27,11 @@ test_username_long {
 	r := main.deny_postgres_main_username_too_long with input as {"resource_changes": [{
 		"address": "foo",
 		"type": "aws_rds_cluster",
-		"change": {"after": {"master_username": "12345678901234567"}},
+		"change": {"after": {"master_username": "1234567890123456789012345678901234567890123456789012345678901234"}},
 	}]}
 
 	count(r) == 1
-	r[_] == "Postgresql main username > 16 characters: [\"foo\"]"
+	r[_] == "Postgresql main username > 63 characters: [\"foo\"]"
 }
 
 test_username_valid_length {


### PR DESCRIPTION
# Summary
Update the Postgres max username check to allow usernames that 
are up to 63 characters in length.  [From the docs](https://www.postgresql.org/docs/current/runtime-config-preset.html#:~:text=The%20default%20value%20of%20NAMEDATALEN,characters%20when%20using%20multibyte%20encodings.&text=Reports%20the%20maximum%20number%20of%20index%20keys.):

> ### max_identifier_length (integer):
> Reports the maximum identifier length. It is determined as one
> less than the value of `NAMEDATALEN` when building the server.
> The default value of `NAMEDATALEN` is 64; therefore the default
> max_identifier_length is 63 bytes, which can be less than 63
> characters when using multibyte encodings.

# Related
- cds-snc/platform-core-services#427