### PR TITLE
chore: Add nodejs 18 as valid runtime

### DIFF
--- a/aws_terraform/unsupported_lambda_runtime.rego
+++ b/aws_terraform/unsupported_lambda_runtime.rego
@@ -3,8 +3,6 @@ package main
 valid_runtimes = {
 	"nodejs18.x",
 	"nodejs16.x",
-	"nodejs14.x",
-	"nodejs12.x",
 	"python3.9",
 	"python3.8",
 	"python3.7",

--- a/aws_terraform/unsupported_lambda_runtime.rego
+++ b/aws_terraform/unsupported_lambda_runtime.rego
@@ -3,6 +3,7 @@ package main
 valid_runtimes = {
 	"nodejs18.x",
 	"nodejs16.x",
+	"nodejs14.x",
 	"python3.9",
 	"python3.8",
 	"python3.7",

--- a/aws_terraform/unsupported_lambda_runtime.rego
+++ b/aws_terraform/unsupported_lambda_runtime.rego
@@ -1,6 +1,7 @@
 package main
 
 valid_runtimes = {
+	"nodejs18.x",
 	"nodejs16.x",
 	"nodejs14.x",
 	"nodejs12.x",

--- a/test_inputs/lambda.tf
+++ b/test_inputs/lambda.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "test_lambda_with_good_runtime" {
 
   source_code_hash = filebase64sha256("mocks/test.zip")
 
-  runtime = "nodejs12.x"
+  runtime = "nodejs18.x"
 }
 
 resource "aws_lambda_function" "test_lambda_with_bad_runtime" {
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "test_lambda_with_bad_runtime" {
 
   source_code_hash = filebase64sha256("mocks/test.zip")
 
-  runtime = "nodejs10.x"
+  runtime = "nodejs12.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda_with_eni" {
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "test_vpc_lambda_with_eni_policy" {
 
   source_code_hash = filebase64sha256("mocks/test.zip")
 
-  runtime = "nodejs12.x"
+  runtime = "nodejs16.x"
 
   vpc_config {
     security_group_ids = []
@@ -89,7 +89,7 @@ resource "aws_lambda_function" "test_vpc_lambda_with_missing_eni_policy" {
 
   source_code_hash = filebase64sha256("mocks/test.zip")
 
-  runtime = "nodejs12.x"
+  runtime = "nodejs16.x"
 
   vpc_config {
     security_group_ids = []


### PR DESCRIPTION
# Summary | Résumé

Adding Node JS 18 as a valid runtime now that it is the recommended Node JS platform.
Removed Node JS 12 and Node JS 14 as valid runtimes.

> We are ending support for Node.js 14 in AWS Lambda. This follows Node.js 14 End-Of-Life (EOL) reached on April 30, 2023 [1].
> 
> As described in the Lambda runtime support policy [2], end of support for language runtimes in Lambda happens in two stages. Starting November 27, 2023, Lambda will no longer apply security patches and other updates to the Node.js 14 runtime used by Lambda functions, and functions using Node.js 14 will no longer be eligible for technical support. In addition, you will no longer be able to create new Lambda functions using the Node.js 14 runtime. Starting January 25, 2024, you will no longer be able to update existing functions using the Node.js 14 runtime.
> 
> We recommend that you upgrade your existing Node.js 14 functions to Node.js 18 before November 27, 2023.
