### PR TITLE
fix: add `python3.12` Lambda runtime

### DIFF
--- a/aws_terraform/unsupported_lambda_runtime.rego
+++ b/aws_terraform/unsupported_lambda_runtime.rego
@@ -6,7 +6,7 @@ valid_runtimes = {
 	"nodejs20.x",
 	"nodejs18.x",
 	"nodejs16.x",
-	"python3.12",	
+	"python3.12",
 	"python3.11",
 	"python3.10",
 	"python3.9",

--- a/aws_terraform/unsupported_lambda_runtime.rego
+++ b/aws_terraform/unsupported_lambda_runtime.rego
@@ -6,6 +6,7 @@ valid_runtimes = {
 	"nodejs20.x",
 	"nodejs18.x",
 	"nodejs16.x",
+	"python3.12",	
 	"python3.11",
 	"python3.10",
 	"python3.9",


### PR DESCRIPTION
# Summary
Update the list of valid Lambda runtimes to include Python 3.12.

# Related
- https://github.com/cds-snc/platform-core-services/issues/471