### PR TITLE
feat: DENY on universal principal for lambda policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 | Container name spaces | Checks if ECS container definitions have a name with spaces in it | DENY |
 | Container definition trailing commas | Checks if ECS container definitions have trailing commas in it | DENY |
 | Invalid effect | IAM Policy `Effect` is only `Approve` or `Deny`| DENY |
+| Lambda permission public principal | Lambda permissions cannot use a public `*` principal | DENY |
 | Lambda VPC ENI permission | A lambda attached to a VPC is missing the permissions to mange an ENI | DENY |
 | Postgres DB password | Postgres DB password is:<ul><li>greater than 8 characters</li><li>only has valid characters</li><li>is not on the reserved list</li></ul> | DENY |
 | Postgres DB username | Postgres DB username is:<ul><li>greater than 16 characters</li><li>only has valid characters</li><li>is not on the reserved list</li></ul> | DENY |

--- a/aws_terraform/lambda_permission_public_principal.rego
+++ b/aws_terraform/lambda_permission_public_principal.rego
@@ -1,0 +1,16 @@
+package main
+
+lambda_permissions_with_public_principal[r] = resources {
+	changes := input.resource_changes[r]
+	resources := [resource |
+		resource := changes.address
+		changes.type == "aws_lambda_permission"
+		changes.change.after.principal == "*"
+	]
+}
+
+deny_lambda_permission_public_principal[msg] {
+	resources := lambda_permissions_with_public_principal[_]
+	resources != []
+	msg := sprintf("Lambda permission has public principal: %v", [resources])
+}

--- a/aws_terraform/lambda_permission_public_principal_test.rego
+++ b/aws_terraform/lambda_permission_public_principal_test.rego
@@ -1,0 +1,34 @@
+package tests
+
+import data.main as main
+
+test_lambda_permission_with_cloudfront_principal {
+	r := main.deny_lambda_permission_public_principal with input as {"resource_changes": [{
+		"address": "foo",
+		"type": "aws_lambda_permission",
+		"change": {"after": {"principal": "cloudfront.amazonaws.com"}},
+	}]}
+
+	count(r) == 0
+}
+
+test_lambda_permission_with_public_principal {
+	r := main.deny_lambda_permission_public_principal with input as {"resource_changes": [{
+		"address": "foo",
+		"type": "aws_lambda_permission",
+		"change": {"after": {"principal": "*"}},
+	}]}
+
+	count(r) == 1
+	r[_] == "Lambda permission has public principal: [\"foo\"]"
+}
+
+test_non_lambda_permission_with_public_principal {
+	r := main.deny_lambda_permission_public_principal with input as {"resource_changes": [{
+		"address": "foo",
+		"type": "aws_iam_policy",
+		"change": {"after": {"principal": "*"}},
+	}]}
+
+	count(r) == 0
+}

--- a/test_inputs/lambda.tf
+++ b/test_inputs/lambda.tf
@@ -40,6 +40,13 @@ resource "aws_lambda_function" "test_lambda_with_bad_runtime" {
   runtime = "nodejs12.x"
 }
 
+resource "aws_lambda_permission" "test_lambda_with_public_principal" {
+  statement_id  = "AllowPublicInvokeFunction"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test_lambda_with_good_runtime.function_name
+  principal     = "*"
+}
+
 resource "aws_iam_role" "iam_for_lambda_with_eni" {
   name = "iam_for_lambda_with_eni"
 


### PR DESCRIPTION
Closes #57 

This pull request adds a new policy check to prevent AWS Lambda permissions from being granted to a public principal (`*`). The change includes the policy definition, corresponding tests, and documentation updates.

**New Lambda permission policy:**

* Added a new Rego policy in `aws_terraform/lambda_permission_public_principal.rego` that denies Lambda permissions with a public `*` principal.
* Added tests in `aws_terraform/lambda_permission_public_principal_test.rego` to verify the new policy correctly allows valid principals and denies public principals for Lambda permissions.

**Documentation:**

* Updated the `README.md` to document the new "Lambda permission public principal" check.